### PR TITLE
fix: Correct JPA imports for Veiculo entity

### DIFF
--- a/src/main/java/web/onficina/model/Veiculo.java
+++ b/src/main/java/web/onficina/model/Veiculo.java
@@ -1,11 +1,11 @@
 package web.onficina.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "veiculo")


### PR DESCRIPTION
Changed JPA imports in `web.onficina.model.Veiculo.java` from `javax.persistence.*` to `jakarta.persistence.*`.

This resolves an `IllegalArgumentException: Not a managed type` error that occurred at application startup due to the `Veiculo` entity not being recognized by Hibernate/JPA in a Spring Boot 3.x environment. The `jakarta.persistence` namespace is standard for this version of Spring Boot.